### PR TITLE
remove static from move_logic

### DIFF
--- a/m-ex-master/m-ex-master/examples/gnw/src/gnw.c
+++ b/m-ex-master/m-ex-master/examples/gnw/src/gnw.c
@@ -10,8 +10,7 @@
 // In this example, we replace the IASA (interruptible as soon as) callback for ground & air down special at lines 430, and 465
 // When creating fully custom states though, often many fields such as the 
 // AnimationID, AnimationCallback, IASACallback, PhysicsCallback, and CollisionCallback are completely changed and replaced with custom functions
-__attribute__((used))
-static struct FtState move_logic[] = {
+struct FtState move_logic[] = {
 	// State: 341 - Attack11
 	{
 		46,         // AnimationID


### PR DESCRIPTION
The `static` attribute in C means that the object should be purely local to that file, and should not be seen when linking. We want mextk to be able to see this object, so it shouldn't be static.

But there may be some reason static is used, so feel free to discard this pr if so!